### PR TITLE
properly escape boolaens for writing

### DIFF
--- a/geopetl/postgis.py
+++ b/geopetl/postgis.py
@@ -726,7 +726,14 @@ class PostgisTable(object):
             elif 'timestamptz' not in str(val).lower():
                 val = '''TIMESTAMPTZ '{}' '''.format(val)
         elif type_ == 'boolean':
-            val = val if val else 'NULL'
+            # if we don't convert to string, then our val join in write() will fail to join the value
+            # since it will be a True/False value
+            if (val == True) or (val == False):
+                val = str(val)
+            elif not val:
+                val = 'NULL'
+            else:
+                val = val
         elif type_ == 'money':
             if not val:
                 val = 'NULL'


### PR DESCRIPTION
Trying to directly write a dataset between 2 Postgres instances that has a boolean column with a straight "fromdb" and "topostgis" causes this error:
```
File "/home/ubuntu/databridge-airflow/env/src/geopetl/geopetl/postgis.py", line 871, in <listcomp>
    vals_joined = ['({})'.format(', '.join(vals)) for vals in val_rows]
TypeError: sequence item 67: expected str instance, bool found
```

Escaping the boolean with a str in prepar_val fixes it.

Edit: @Alexander-M-Waldman wants to wait for tests to be made first before merging this. (issue: https://github.com/CityOfPhiladelphia/geopetl/issues/92)