### PR TITLE
dont make extract schema functions shadow each other

### DIFF
--- a/geopetl/oracle_sde.py
+++ b/geopetl/oracle_sde.py
@@ -16,12 +16,12 @@ import cx_Oracle
 
 DEFAULT_WRITE_BUFFER_SIZE = 1000
 
-def extract_table_schema(dbo, table_name, table_schema_output_path):
+def oracle_extract_table_schema(dbo, table_name, table_schema_output_path):
     db = OracleSdeDatabase(dbo)
     table = db.table(table_name)
     table.extract_table_schema(table_schema_output_path)
 
-etl.extract_table_schema = extract_table_schema
+etl.oracle_extract_table_schema = oracle_extract_table_schema
 
 def fromoraclesde(dbo, table_name, **kwargs):
     db = OracleSdeDatabase(dbo)

--- a/geopetl/postgis.py
+++ b/geopetl/postgis.py
@@ -44,12 +44,12 @@ GEOM_TYPE_MAP = {
     'geometry':        'Geometry',
 }
 
-def extract_table_schema(dbo, table_name, table_schema_output_path):
+def postgres_extract_table_schema(dbo, table_name, table_schema_output_path):
     db = PostgisDatabase(dbo)
     table = db.table(table_name)
     table.extract_table_schema(table_schema_output_path)
 
-etl.extract_table_schema = extract_table_schema
+etl.postgres_extract_table_schema = postgres_extract_table_schema
 
 def frompostgis(dbo, table_name, fields=None, return_geom=True, geom_with_srid=False,
                 where=None, limit=None, sql=None):


### PR DESCRIPTION
With the new databridge-etl-tool changes, running an extract like this wasn't working as it would be using the postgis class from geopetl, probably because of how we pull in geopetl on top of petl.

```
docker run --rm dbtools databridge_etl_tools oracle \
  --table_name=point_table_2272 \
  --table_schema=GIS_TEST \
  --connection_string=some_conn_string \
  --s3_bucket=some_bucket \
  --s3_key=schemas/test/point_table_2272.json extract-json-schema
 ```
 
 Changing the names to be specific to their db type makes them not overshadow each other.