### PR TITLE
Assert self.srid is not None for geometric writes

### DIFF
--- a/geopetl/oracle_sde.py
+++ b/geopetl/oracle_sde.py
@@ -959,7 +959,6 @@ class OracleSdeTable(object):
                 # SRID cannot be None here! This will result in this being used in the prepare statment:
                 #SDE.ST_GEOMETRY(:SHAPE, NONE))
                 # which ends with this error: cx_Oracle.DatabaseError: ORA-00984: column not allowed here
-                print('Making sure we have an SRID value..')
                 assert insert_srid, "SRID cannot be None when writing to geometric tables!"
                 geom_placeholder = f'SDE.ST_Geometry(:{field}, {insert_srid})'
                 placeholders.append(geom_placeholder)


### PR DESCRIPTION
My new oracle load method in databridge_etl_tools failed because it was first trying to write to a temporarily made table that was unregistered. Geopetl failed hard with an ambiguous "ORA-00984: column not allowed here" error because this value was being used for the prepare_stmt:

SDE.ST_GEOMETRY(:SHAPE, NONE))

The second arg to that can't be None.

So, use some logic to determine what should be using for the "insert_srid" if any.