### PR TITLE
dont activate oracle by default

### DIFF
--- a/geopetl/__init__.py
+++ b/geopetl/__init__.py
@@ -3,7 +3,6 @@ from geopetl.util import parse_db_url
 
 # activate all extensions
 import geopetl.carto
-import geopetl.oracle_sde
 import geopetl.postgis
 
 # activate transforms


### PR DESCRIPTION
Necessary if something like databridge_etl_tools doesn't need oracle and doesn't have cx_Oracle installed. Not sure why things are loaded at the __init__ when we're not sure if they'll be used.